### PR TITLE
Minor changes to get building on Linux

### DIFF
--- a/OctNode.h
+++ b/OctNode.h
@@ -1,7 +1,7 @@
 #ifndef __OCT_NODE_H__
 #define __OCT_NODE_H__
 
-#include "./resln.h"
+#include "./Resln.h"
 #include "./bb.h"
 
 namespace Karras {

--- a/viewer/fit_main.cpp
+++ b/viewer/fit_main.cpp
@@ -246,7 +246,7 @@ void DrawSeparator(float_seg A, float_seg B, const float& min_d) {
   glEnd();
 }
 
-void Display() {
+void FitDisplay() {
   glClear(GL_COLOR_BUFFER_BIT);
 
   // draw quadtree
@@ -350,7 +350,7 @@ int main(int argc, char** argv) {
   glutInitWindowSize(window_width, window_height);
   glutInitWindowPosition(0, 0);
   glutCreateWindow("fit");
-  glutDisplayFunc(Display);
+  glutDisplayFunc(FitDisplay);
   glutKeyboardFunc(Keyboard);
   glutMouseFunc(Mouse);
   glutMotionFunc(MouseMotion);


### PR DESCRIPTION
I had to change one of the header includes to use the correct case on my case-sensitive Linux system.

Also, the `Display` symbol was already declared by xlib, so I had to rename that to `FitDisplay`.
